### PR TITLE
test: name qualifier and no qualifier aligns with Guice

### DIFF
--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/ContextGetBeanTest.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/ContextGetBeanTest.java
@@ -1,0 +1,29 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class ContextGetBeanTest {
+    @Inject
+    BeanContext context;
+
+    @Test
+    void qualifiedBeanFromContextGetBean() {
+        assertEquals("Ahoy", context.getBean(Greeter.class, Qualifiers.byName("pirate")).hello());
+
+    }
+    
+    @Disabled("io.micronaut.context.exceptions.NonUniqueBeanException: Multiple possible bean candidates found: [Greeter, Greeter]")
+    @Test
+    void contextGetBean() {
+        assertEquals("Hello", context.getBean(Greeter.class).hello());
+
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/DefaultGreeter.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/DefaultGreeter.java
@@ -1,0 +1,8 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+public class DefaultGreeter implements Greeter {
+    @Override
+    public String hello() {
+        return "Hello";
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/Greeter.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/Greeter.java
@@ -1,0 +1,6 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+public interface Greeter {
+
+    String hello();
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GreeterApplication.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GreeterApplication.java
@@ -1,0 +1,5 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+@io.micronaut.guice.annotation.Guice(modules = GreeterModule.class, classes = { DefaultGreeter.class, PirateGreeter.class })
+public class GreeterApplication {
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GreeterModule.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GreeterModule.java
@@ -1,0 +1,13 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import com.google.inject.name.Names;
+
+public class GreeterModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(Greeter.class).annotatedWith(Names.named("pirate")).to(PirateGreeter.class).in(Scopes.SINGLETON);
+        bind(Greeter.class).to(DefaultGreeter.class).in(Scopes.SINGLETON);
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GuiceTest.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/GuiceTest.java
@@ -1,0 +1,16 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GuiceTest {
+    @Test
+    void guiceByDefaultUsesLastDeclaration() {
+        Injector injector = Guice.createInjector(new GreeterModule());
+        Greeter greeter = injector.getInstance(Greeter.class);
+        assertEquals("Hello", greeter.hello());
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithGuiceNamedQualifierTest.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithGuiceNamedQualifierTest.java
@@ -1,0 +1,22 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import com.google.inject.name.Named;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class InjectionWithGuiceNamedQualifierTest {
+
+    @Inject
+    @Named("pirate")
+    Greeter greeter;
+
+    @Test
+    void qualifiedBeanFromContextGetBean() {
+        assertEquals("Ahoy", greeter.hello());
+
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithJakartaNamedQualifierTest.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithJakartaNamedQualifierTest.java
@@ -1,0 +1,22 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class InjectionWithJakartaNamedQualifierTest {
+
+    @Inject
+    @Named("pirate")
+    Greeter greeter;
+
+    @Test
+    void qualifiedBeanFromContextGetBean() {
+        assertEquals("Ahoy", greeter.hello());
+
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithoutQualifierTest.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/InjectionWithoutQualifierTest.java
@@ -1,0 +1,21 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest(startApplication = false)
+class InjectionWithoutQualifierTest {
+
+    @Inject
+    Greeter greeter;
+
+    @Disabled("io.micronaut.context.exceptions.NonUniqueBeanException: Multiple possible bean candidates found: [Greeter, Greeter]")
+    @Test
+    void qualifiedBeanFromContextGetBean() {
+        assertEquals("Hello", greeter.hello());
+    }
+}

--- a/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/PirateGreeter.java
+++ b/micronaut-guice/src/test/java/io/micronaut/guice/doc/examples/bindings/defaultimplementation/PirateGreeter.java
@@ -1,0 +1,8 @@
+package io.micronaut.guice.doc.examples.bindings.defaultimplementation;
+
+public class PirateGreeter implements Greeter {
+    @Override
+    public String hello() {
+        return "Ahoy";
+    }
+}


### PR DESCRIPTION
For a Guice module:

```java
public class GreeterModule extends AbstractModule {
    @Override
    protected void configure() {
        bind(Greeter.class).to(DefaultGreeter.class).in(Scopes.SINGLETON);
        bind(Greeter.class).annotatedWith(Names.named("pirate")).to(PirateGreeter.class).in(Scopes.SINGLETON);
    }
```

Guice returns `DefaultGreeter` when you dou:

```java
Injector injector = Guice.createInjector(new GreeterModule());
Greeter greeter = injector.getInstance(Greeter.class);
```

However, Micronaut returns ` Multiple possible bean candidates found: [Greeter, Greeter]` for:

``java
@Inject
io.micronaut.context.BeanContext context;

@Test
void contextGetBean() {
context.getBean(Greeter.class)
}
```